### PR TITLE
Support zsh's EXTENDED_HISTORY

### DIFF
--- a/hist
+++ b/hist
@@ -144,6 +144,7 @@ _import_zsh_extended_history() {
         SELECT 'Imported ' || value || ' item(s).' FROM variables WHERE key = 'items';
 SQL
     ) | "${HISTORIAN_SQLITE3}" "${HISTORIAN_DB}";
+    [ -n "$tmpdir" ] && rm -rf $tmpdir
 }
 
 cmd_log() {

--- a/hist
+++ b/hist
@@ -9,6 +9,11 @@ MAGIC_ENUM_QUOTE=1
 
 SEPARATOR=$(echo -e "\x01")
 
+# Other ENV parameters:
+#
+# - ZSH_EXTENDED_HISTORY: if set, parses HISTORIAN_SRC using zsh's
+#   EXTENDED_HISTORY format
+
 usage() {
     echo "Usage: hist <subcommand>" >&2
     echo "subcommands:" >&2
@@ -90,6 +95,14 @@ cmd_import() {
         | sed -e 's/"/'$(get_magic ${MAGIC_ENUM_QUOTE})'/g' \
         > "${sanitized_src}" \
     ;
+    if [ -n "${ZSH_EXTENDED_HISTORY}" ]; then
+        _import_zsh_extended_history;
+    else
+        _import_default;
+    fi
+}
+
+_import_default() {
     ( cat <<SQL
         CREATE TEMPORARY TABLE variables
             (key TEXT, value INTEGER);
@@ -108,6 +121,29 @@ cmd_import() {
 SQL
     ) | "${HISTORIAN_SQLITE3}" "${HISTORIAN_DB}";
     rm -f ${sanitized_src};
+}
+
+# http://zsh.sourceforge.net/Doc/Release/Options.html#History
+_import_zsh_extended_history() {
+    local tmpdir=$(mktemp -d)
+    tmp_src=${tmpdir}/$(basename $HISTORIAN_SRC)
+    sed -e 's/^: \([0-9][0-9]*\):\([0-9][0-9]*\);/\1'${SEPARATOR}'/g' ${HISTORIAN_SRC} \
+        > ${tmp_src}
+    ( cat <<SQL
+        CREATE TEMPORARY TABLE variables
+            (key TEXT, value INTEGER);
+        INSERT INTO variables(key, value)
+            SELECT 'items', COUNT(*) FROM history;
+        CREATE TEMPORARY TABLE history_import (timestamp INTEGER, command TEXT);
+.separator ${SEPARATOR}
+.import ${tmp_src} history_import
+        INSERT OR IGNORE INTO history(timestamp, command)
+            SELECT timestamp, command FROM history_import;
+        UPDATE variables
+            SET value = -1 * value + (SELECT COUNT(*) FROM history); -- lol subtraction
+        SELECT 'Imported ' || value || ' item(s).' FROM variables WHERE key = 'items';
+SQL
+    ) | "${HISTORIAN_SQLITE3}" "${HISTORIAN_DB}";
 }
 
 cmd_log() {

--- a/hist
+++ b/hist
@@ -7,6 +7,8 @@ HISTORIAN_SQLITE3=${HISTORIAN_SQLITE3-"$(which sqlite3)"}
 MAGIC="$(echo -e "\x10\x83\xB9\x9F\x34\xB5\x96\x45")" # 0118 999 881 999 119 725 3
 MAGIC_ENUM_QUOTE=1
 
+SEPARATOR=$(echo -e "\x01")
+
 usage() {
     echo "Usage: hist <subcommand>" >&2
     echo "subcommands:" >&2
@@ -94,7 +96,7 @@ cmd_import() {
         INSERT INTO variables(key, value)
             SELECT 'items', COUNT(*) FROM history;
         CREATE TEMPORARY TABLE history_import (line TEXT);
-.separator $(echo -e "\x01")
+.separator ${SEPARATOR}
 .import ${sanitized_src} history_import
         UPDATE history_import
             SET line = REPLACE(line, '$(get_magic ${MAGIC_ENUM_QUOTE})', '"');

--- a/test/test_import.sh
+++ b/test/test_import.sh
@@ -82,3 +82,39 @@ EOF
     assert_equal 0 $?
     rm -f $tmp
 }
+
+htest_import_zsh_extended_history_parses_correctly() {
+    cat >> $sandbox/.bash_history <<EOF
+: 1492369835:0;hist import
+: 1492369844:0;hist /hist import
+: 1492369861:4;hist shell
+: 1492369868:0;hist version
+: 1492369908:0;hist /hist | wc -l
+: 1492370096:30;history
+: 1492370103:0;man history
+: 1492370245:0;history-stat
+: 1492370604:50;vi $HISTFILE
+: 1492370674:0;tail $HISTFILEfoo
+EOF
+
+    cat >> $sandbox/expected_commands.psv <<EOF
+1492369835|hist import
+1492369844|hist /hist import
+1492369861|hist shell
+1492369868|hist version
+1492369908|hist /hist | wc -l
+1492370096|history
+1492370103|man history
+1492370245|history-stat
+1492370604|vi $HISTFILE
+1492370674|tail $HISTFILEfoo
+EOF
+
+    ZSH_EXTENDED_HISTORY=1 \
+        sandbox_hist import
+
+    sandbox_sql "SELECT timestamp, command FROM history;" \
+        > $sandbox/actual_commands.psv;
+    diff $sandbox/expected_commands.psv $sandbox/actual_commands.psv;
+    assert_equal 0 $? "rows imported with ZSH_EXTENDED_HISTORY set should match"
+}


### PR DESCRIPTION
Per https://github.com/jcsalterego/historian/issues/5, introduce new parsing when `ZSH_EXTENDED_HISTORY` which aligns with zsh's `EXTENDED_HISTORY` parameter: http://zsh.sourceforge.net/Doc/Release/Options.html#History

This begins use of the `timestamp` column in the `history` table.